### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,87 @@
+# ProtoSchool Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+Note that each ProtoSchool [chapter](https://proto.school/chapters) also maintains
+its own Code of Conduct. Please visit your chapter's website or repository to view
+additional policies that may apply to its events, website, and repos.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at protoschool@protocol.ai. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+Please note that each ProtoSchool [chapter](https://proto.school/chapters)
+maintains its own Code of Conduct with additional guidance for local events and
+chapter repositories. To report instances of abusive, harassing, or
+otherwise unacceptable behavior that have occured within chapter events or repos,
+please reach out to your local chapter leadership using the contact information
+provided in their chapter CoC. 
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ _For more background on ProtoSchool or other ways to get involved, like building
 
 ## How to start a new ProtoSchool chapter
 
-Whether you're an existing organizer or hope to become one, please read our [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md). All chapter organizers are expected to follow these guidelines to ensure the ProtoSchool community remains a welcoming place for all learners.
+Whether you're an existing organizer or hope to become one, please read our [Code of Conduct](https://github.com/protoschool/organizing/blob/master/CODE_OF_CONDUCT.md). All chapter organizers are expected to follow these guidelines to ensure the ProtoSchool community remains a welcoming place for all learners.
 
 Check out our [list of existing chapters](https://proto.school/chapters.html) to see if there's already a group near you. If not, please [open an issue](https://github.com/protoschool/organizing/issues/new?labels=new-chapter&title=New%20Chapter%20Request&body=Please%20introduce%20yourself%20and%20tell%20us%20where%20you'd%20like%20to%20host%20a%20ProtoSchool%20chapter.) on this repo asking to be added as a chapter organizer. This is an opportunity to introduce yourself and why you're interested in organizing. Here's an example to get you started:
 
@@ -24,7 +24,16 @@ Once you are an organizer, follow these instructions to set up the web presence 
 **Step 2**
 Each chapter can set up their own `gh-pages` branch on their org and [GitHub Pages](https://help.github.com/categories/github-pages-basics/) will automatically route http://proto.school/<reponame> to it.
 
-**Step 3** | You should create a Code of Conduct for your website and repository. You can use this template as a starting point. Be sure to make all people feel welcome at your event.
+**Step 3**
+You should create a Code of Conduct for your website and repository. The [Contributor Covenant](https://www.contributor-covenant.org/) provides a nice template.
+
+You should also create a Code of Conduct for your events, as part of the broader effort
+to make all people feel welcome. The [Conference Code of Conduct](http://confcodeofconduct.com/)
+provides a nice starting point, but will require some adaptation to the specifics
+of your events.
+
+In any Code of Conduct you create, be sure to include contact information for
+reporting any incidents to chapter leadership.
 
 
 **Step 4** | _This step is important for discoverability!_

--- a/README.md
+++ b/README.md
@@ -38,9 +38,11 @@ reporting any incidents to chapter leadership.
 
 **Step 4** | _This step is important for discoverability!_
 
-Once your chapter is up and running, make a pull request to the ProtoSchool website to add a chapter JSON file to the `/chapters` directory. When your request is accepted, your chapter will be automatically added to the listings at http://proto.school/#/chapters
+Once your chapter is up and running, make a pull request to the ProtoSchool website
+to add you chapter to the existing `chapters.json` file in the `/chapters` directory.
+When your pull request is accepted, your chapter will be automatically added to the listings at http://proto.school/#/chapters
 
-Your chapter JSON file should look something like this:
+Your addition to the `chapters.json` file should look something like this:
 
 ```
 {


### PR DESCRIPTION
This PR adds a Code of Conduct adapted from the Contributors Convent but customized to include our own reporting info and a note about how each chapter will create their own CoC.

Also in this PR are updated instructions for adding your chapter to our listing.